### PR TITLE
Add prefer-flat-map and prefer-flat rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,9 @@ module.exports = {
         "from-map": require("./rules/from-map"),
         "no-unnecessary-this-arg": require("./rules/no-unnecessary-this-arg"),
         "prefer-array-from": require("./rules/prefer-array-from"),
-        "avoid-reverse": require("./rules/avoid-reverse")
+        "avoid-reverse": require("./rules/avoid-reverse"),
+        "prefer-flat-map": require("./rules/prefer-flat-map"),
+        "prefer-flat": require("./rules/prefer-flat")
     },
     configs: {
         recommended: {


### PR DESCRIPTION
This adds `prefer-flat-map` and `prefer-flat` to exported rules.

**Fixes ESLint errors:**

- `"Definition for rule 'array-func/prefer-flat-map' was not found"`
- `"Definition for rule 'array-func/prefer-flat' was not found"`