### PR TITLE
docs: Fix "array-from" to "from-map"

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ To use this rule, your `.eslintrc.json` should at least contain the following (m
     "array-func"
   ],
   "rules": {
-    "array-func/array-from": "error"
+    "array-func/from-map": "error"
   }
 }
 ```


### PR DESCRIPTION
Fix [_Using the rule_](https://github.com/freaktechnik/eslint-plugin-array-func/tree/v3.1.8#using-the-rule) of `from-map` in README: `"array-func/array-from": "error"` to `"array-func/from-map": "error"`.