### PR TITLE
Fix Error when mapCallback is not an identifier or a function expression

### DIFF
--- a/rules/from-map.js
+++ b/rules/from-map.js
@@ -10,6 +10,10 @@ const { ARROW_FUNCTION_EXPRESSION } = require("../lib/type"),
         { name: 'index' }
     ];
 
+function isFunction(node) {
+    return node.type === "ArrowFunctionExpression" || node.type === "FunctionExpression";
+}
+
 module.exports = {
     meta: {
         docs: {
@@ -35,8 +39,10 @@ module.exports = {
                 node = callee.parent;
 
                 if(mapCallback.type === "Identifier" ||
-                    mapCallback.params.length > ALL_PARAMS.length ||
-                    mapCallback.params.some((parameter) => parameter.type === "RestElement")
+                    (isFunction(mapCallback) && (
+                        mapCallback.params.length > ALL_PARAMS.length ||
+                        mapCallback.params.some((parameter) => parameter.type === "RestElement")
+                    ))
                 ) {
                     return;
                 }

--- a/test/helpers/from-map-test-cases.mjs
+++ b/test/helpers/from-map-test-cases.mjs
@@ -71,6 +71,15 @@ export default {
                 line: 1
             } ],
             output: 'Array.from(iterable, (item, index) => ((u, i) => u.name)((mapper).call(this, item, index), index))'
+        },
+        {
+            code: 'Array.from(iterable).map(getValue ? (u, i) => getValue(i) : (u, i) => i)',
+            errors: [ {
+                messageId: 'useMapCb',
+                column: 1,
+                line: 1
+            } ],
+            output: 'Array.from(iterable, getValue ? (u, i) => getValue(i) : (u, i) => i)'
         }
     ]
 };


### PR DESCRIPTION
If the first arg to `map` is not an `Identifier` or a function expression (arrow or regular) the check of `params.length` will throw.

We ran into this error with code almost identical to the test case I added. I'm looking to introduce this rule in our codebase and hoping we can get it fixed and published instead of having to fork it. Thanks for creating this plugin!